### PR TITLE
migrate runProguard to minifyEnabled

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,14 +6,14 @@ android {
 
     defaultConfig {
         applicationId "com.example.helloworld"
-        minSdkVersion 15
-        targetSdkVersion 15
+        minSdkVersion 19
+        targetSdkVersion 19
         versionCode 1
         versionName "1.0"
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
fixes error: `Gradle DSL method not found: 'runProguard'`

by swapping out `runProguard` for `minifyEnabled` per [this Stack Overflow thread](http://stackoverflow.com/questions/27078075/gradle-dsl-method-not-found-runproguard)
